### PR TITLE
feat: 开机动画（boot.mp4 + 任意键跳过）

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ graph TD
 
 播放程序与电子通行证固件一起分发，可在[https://github.com/rhodesepass/buildroot/releases](https://github.com/rhodesepass/buildroot/releases)下载最新固件。
 
+## 开机动画
+
+将视频命名为 `boot.mp4`（编码约定与干员视频一致：360x640 显示、H.264），放到设备的
+`/assets/boot.mp4` 或 `/sd/assets/boot.mp4`，主程序启动时会在首次干员切换前全屏播放：
+
+- 时长默认 5 秒（`PRTS_BOOT_ANIM_DURATION_MS`，定义于 `src/config.h`），到点自动进入干员播放；
+- 播放期间按任意按键立即跳过；
+- 未放置该文件时自动跳过，不影响正常启动。
+
 ## 编译方法
 
 ### 直接编译

--- a/src/config.h
+++ b/src/config.h
@@ -64,6 +64,8 @@
 #define PRTS_ASSET_CONFIG_FILENAME "epconfig.json"
 #define PRTS_ASSET_DIR "/assets/"
 #define PRTS_ASSET_DIR_SD SD_MOUNT_POINT "/assets/"
+#define PRTS_BOOT_ANIM_FILE "boot.mp4"
+#define PRTS_BOOT_ANIM_DURATION_MS 5000
 #define PRTS_TICK_PERIOD (1000 * 1000)
 // 相对 res/ 的内置资源 (运行时经 respath()/respath_lvfs() 解析到可执行文件同级)。
 #define PRTS_FALLBACK_ASSET_SUBDIR "fallback"

--- a/src/prts/prts.c
+++ b/src/prts/prts.c
@@ -810,6 +810,83 @@ int prts_operators_reserve(prts_t* prts, int need){
     return 0;
 }
 
+// ============ Boot animation ============
+// Played before the first operator switch; ends by timer or is skipped by key
+// (the LVGL key callback calls prts_boot_anim_skip()).
+static prts_timer_handle_t s_boot_anim_timer;
+static bool s_boot_anim_timer_active;
+
+static void prts_boot_anim_finish(prts_t* prts){
+    if(prts->state != PRTS_STATE_BOOT_ANIM){
+        return;
+    }
+    log_info("boot animation end, switching to first operator");
+    // Leave the state first, so a concurrent timer callback / key press
+    // cannot enter this path twice.
+    prts->state = PRTS_STATE_IDLE;
+    if(s_boot_anim_timer_active){
+        s_boot_anim_timer_active = false;
+        prts_timer_cancel(s_boot_anim_timer);
+    }
+    mediaplayer_stop(&g_mediaplayer);
+    switch_operator(prts, 0);
+}
+
+static void prts_boot_anim_timer_cb(void* userdata, bool is_last){
+    prts_t* prts = (prts_t*)userdata;
+    s_boot_anim_timer_active = false;
+    prts_boot_anim_finish(prts);
+}
+
+bool prts_boot_anim_active(prts_t* prts){
+    return prts->state == PRTS_STATE_BOOT_ANIM;
+}
+
+void prts_boot_anim_skip(prts_t* prts){
+    if(prts->state != PRTS_STATE_BOOT_ANIM){
+        return;
+    }
+    log_info("boot animation skipped by key");
+    prts_boot_anim_finish(prts);
+}
+
+static bool prts_boot_anim_find_video(char* out, size_t outsz){
+    // SD card assets first, then system /assets.
+    snprintf(out, outsz, "%s%s", PRTS_ASSET_DIR_SD, PRTS_BOOT_ANIM_FILE);
+    if(file_exists_readable(out)){
+        return true;
+    }
+    snprintf(out, outsz, "%s%s", PRTS_ASSET_DIR, PRTS_BOOT_ANIM_FILE);
+    if(file_exists_readable(out)){
+        return true;
+    }
+    return false;
+}
+
+static void prts_start_boot_anim(prts_t* prts){
+    char path[256];
+    if(!prts_boot_anim_find_video(path, sizeof(path))){
+        log_info("boot animation: no %s found, direct first switch", PRTS_BOOT_ANIM_FILE);
+        prts->state = PRTS_STATE_IDLE;
+        switch_operator(prts, 0);
+        return;
+    }
+
+    log_info("boot animation: playing %s (%d ms)", path, PRTS_BOOT_ANIM_DURATION_MS);
+    prts->state = PRTS_STATE_BOOT_ANIM;
+    prts->last_switch_time = get_now_us(); // keep tick from auto-switching during the animation
+    mediaplayer_play_video(&g_mediaplayer, path);
+    prts_timer_create(
+        &s_boot_anim_timer,
+        (uint64_t)PRTS_BOOT_ANIM_DURATION_MS * 1000,
+        0,
+        1,
+        prts_boot_anim_timer_cb,
+        prts
+    );
+    s_boot_anim_timer_active = true;
+}
+
 void prts_init(prts_t* prts, overlay_t* overlay){
     log_info("==> PRTS Initializing...");
     prts->overlay = overlay;
@@ -827,9 +904,8 @@ void prts_init(prts_t* prts, overlay_t* overlay){
 
     log_info("==> PRTS will perform first switch...");
     // 进行第一次干员切换
-    prts->state = PRTS_STATE_IDLE;
     prts->operator_index = 0;
-    switch_operator(prts, 0);
+    prts_start_boot_anim(prts);
     
     prts_timer_create(
         &prts->timer_handle, 

--- a/src/prts/prts.h
+++ b/src/prts/prts.h
@@ -69,6 +69,7 @@ typedef enum {
     PRTS_STATE_INTRO, //入场视频
     PRTS_STATE_TRANSITION_LOOP, // 循环过渡
     PRTS_STATE_PRE_OPINFO, // 显示干员信息前的等待
+    PRTS_STATE_BOOT_ANIM, // 开机动画（首次干员切换前）
 } prts_state_t;
 
 typedef struct {
@@ -110,6 +111,10 @@ int prts_operators_reserve(prts_t* prts, int need);
 
 void prts_request_set_operator(prts_t* prts,int operator_index);
 void prts_request_reload_assets(prts_t* prts);
+
+// 开机动画：首次干员切换前播放 /assets|/sd/assets/boot.mp4，可按键跳过
+bool prts_boot_anim_active(prts_t* prts);
+void prts_boot_anim_skip(prts_t* prts);
 
 // 把 from 处干员移动到 to 处(仅改内存)。由 UI 线程在干员列表排序时直接调用。
 void prts_move_operator(prts_t* prts, int from, int to);

--- a/src/render/lvgl_drm_warp.c
+++ b/src/render/lvgl_drm_warp.c
@@ -27,6 +27,9 @@
 #include "ui_screens/ui_preview.h"
 #include "ui_screens/ui_plane.h"
 
+// Boot animation key-skip: set in lvgl_drm_warp_init().
+static prts_t *s_boot_anim_prts = NULL;
+
 static uint32_t lvgl_drm_warp_tick_get_cb(void)
 {
     return (uint32_t)(get_mono_us() / 1000);
@@ -70,6 +73,11 @@ static void* lvgl_drm_warp_thread_entry(void *arg){
 
 // key_enc_evdev 的 input_cb：转发到手写屏的导航状态机。
 static void screen_key_event_cb(uint32_t key){
+    // 开机动画期间任意键跳过，不进入屏幕导航
+    if(s_boot_anim_prts && prts_boot_anim_active(s_boot_anim_prts)){
+        prts_boot_anim_skip(s_boot_anim_prts);
+        return;
+    }
     screens_handle_key(key);
 }
 
@@ -81,6 +89,7 @@ void lvgl_drm_warp_init(lvgl_drm_warp_t *lvgl_drm_warp,drm_warpper_t *drm_warppe
 
     lvgl_drm_warp->drm_warpper = drm_warpper;
     lvgl_drm_warp->layer_animation = layer_animation;
+    s_boot_anim_prts = prts;
 
     // 单 buffer 直绘(同 overlay)：只分配一块扫描 FB，挂载一次后不走 flip 队列。
     drm_warpper_allocate_buffer(drm_warpper, DRM_WARPPER_LAYER_UI, &lvgl_drm_warp->ui_buf);


### PR DESCRIPTION
新增开机动画功能：将视频命名为 `boot.mp4` 放到设备的 `/assets/` 或 `/sd/assets/`，主程序启动时在首次干员切换前全屏播放。

- 时长默认 5 秒（`PRTS_BOOT_ANIM_DURATION_MS`，定义于 `src/config.h`），到点自动进入干员播放；
- 播放期间按任意按键立即跳过（经 LVGL 按键回调拦截）；
- 未放置该文件时自动跳过，不影响正常启动；
- README 补充了素材格式与放置说明。

真机验证：384x640 H.264 视频正常解码播放，按键跳过与定时结束两条路径均已确认。