### PR TITLE
fix(win32): 定时器+worker线程修复

### DIFF
--- a/src/overlay/overlay.c
+++ b/src/overlay/overlay.c
@@ -62,12 +62,25 @@ void* overlay_worker_thread(void* arg){
     while(atomic_load(&worker->running)){
         pthread_mutex_lock(&worker->mutex);
 
+#ifdef _WIN32
+        // Windows: 1ms 轮询替代 pthread_cond_wait（winpthreads 下信号不可靠）
+        while(!worker->pending && atomic_load(&worker->running)){
+            pthread_mutex_unlock(&worker->mutex);
+            usleep(1000);
+            pthread_mutex_lock(&worker->mutex);
+        }
+        if(!atomic_load(&worker->running)){
+            pthread_mutex_unlock(&worker->mutex);
+            goto worker_end;
+        }
+#else
         while(!worker->pending){
             pthread_cond_wait(&worker->cond, &worker->mutex);
             if(!atomic_load(&worker->running)){
                 goto worker_end;
             }
         }
+#endif
 
         worker->pending = 0;
         worker->in_progress = 1;
@@ -98,7 +111,9 @@ void overlay_worker_schedule(overlay_t* overlay,void (*func)(void *userdata,int 
         worker->pending = 1;
         worker->func = func;
         worker->userdata = userdata;
+#ifndef _WIN32
         pthread_cond_signal(&worker->cond);
+#endif
     }
     else{
         log_debug("overlay worker can't keep up... dropping task");
@@ -166,8 +181,16 @@ void overlay_abort(overlay_t* overlay){
     );
 
     overlay->request_abort = 1;
+#ifdef _WIN32
+    // WT_EXECUTELONGFUNCTION 保证 worker 线程独立不被本 spin-loop 饿死
+    // 缩短 sleep 加速响应
+    #define ABORT_SLEEP_US (5 * 1000)
+#else
+    #define ABORT_SLEEP_US (50 * 1000)
+#endif
     while(overlay->overlay_timer_handle){
-        usleep(50 * 1000);
+        usleep(ABORT_SLEEP_US);
     }
+#undef ABORT_SLEEP_US
     return;
 }

--- a/src/utils/timer_backend_win32.c
+++ b/src/utils/timer_backend_win32.c
@@ -23,7 +23,11 @@ int os_timer_arm(os_timer_handle_t *h, uint64_t first_us, uint64_t interval_us, 
 {
     DWORD due = us_to_ms_ceil(first_us);
     DWORD period = (interval_us != 0) ? us_to_ms_ceil(interval_us) : 0; // 0 ⇒ one-shot
-    DWORD flags = (interval_us != 0) ? WT_EXECUTEDEFAULT : WT_EXECUTEONLYONCE;
+    DWORD flags = WT_EXECUTEDEFAULT;
+    if(interval_us != 0)
+        flags |= WT_EXECUTELONGFUNCTION;
+    else
+        flags |= WT_EXECUTEONLYONCE;
 
     HANDLE t = NULL;
     if (!CreateTimerQueueTimer(&t, NULL, win_timer_shim,

--- a/src/utils/uuid.c
+++ b/src/utils/uuid.c
@@ -4,67 +4,79 @@
 #include <stdio.h>
 #include "utils/log.h"
 
+#ifdef _WIN32
+
+bool uuid_compare(const uuid_t *a, const uuid_t *b){
+    return IsEqualGUID(a, b);
+}
+
+int uuid_parse(const char *str, uuid_t *uuid){
+    if(strlen(str) != 36) return -1;
+    if(str[8]!='-'||str[13]!='-'||str[18]!='-'||str[23]!='-') return -1;
+    // Win32 UUID 是结构体字段，不能按 data[] 写入；用 sscanf 解析
+    unsigned int d4[8];
+    if(sscanf(str, "%08x-%04hx-%04hx-%02x%02x-%02x%02x%02x%02x%02x%02x",
+              &uuid->Data1, (unsigned short*)&uuid->Data2, (unsigned short*)&uuid->Data3,
+              &d4[0],&d4[1],&d4[2],&d4[3],&d4[4],&d4[5],&d4[6],&d4[7]) != 11)
+        return -1;
+    for(int i=0;i<8;i++) uuid->Data4[i]=(unsigned char)d4[i];
+    return 0;
+}
+
+void uuid_format(const uuid_t *uuid, char *out){
+    snprintf(out,37,"%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             uuid->Data1,uuid->Data2,uuid->Data3,
+             uuid->Data4[0],uuid->Data4[1],uuid->Data4[2],uuid->Data4[3],
+             uuid->Data4[4],uuid->Data4[5],uuid->Data4[6],uuid->Data4[7]);
+}
+
+void uuid_print(const uuid_t *uuid){
+    char buf[37];
+    uuid_format(uuid, buf);
+    log_debug("%s", buf);
+}
+
+#else
+
 bool uuid_compare(const uuid_t *a, const uuid_t *b){
     return memcmp(a->data, b->data, 16) == 0;
 }
 int uuid_parse(const char *str, uuid_t *uuid){
-    if(strlen(str) != 36){
-        return -1;
-    }
-    if(str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-'){
-        return -1;
-    }
-    // Parse a UUID string in the form "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    int i = 0, j = 0;
-    for (i = 0, j = 0; i < 36 && j < 16; ) {
-        if (str[i] == '-') {
-            i++;
-            continue;
-        }
-        int hi, lo;
-        char c1 = str[i];
-        char c2 = str[i+1];
-        if ('0' <= c1 && c1 <= '9') hi = c1 - '0';
-        else if ('a' <= c1 && c1 <= 'f') hi = c1 - 'a' + 10;
-        else if ('A' <= c1 && c1 <= 'F') hi = c1 - 'A' + 10;
+    if(strlen(str) != 36) return -1;
+    if(str[8]!='-'||str[13]!='-'||str[18]!='-'||str[23]!='-') return -1;
+    int i,j;
+    for(i=0,j=0;i<36&&j<16;){
+        if(str[i]=='-'){i++;continue;}
+        int hi,lo;
+        char c1=str[i],c2=str[i+1];
+        if('0'<=c1&&c1<='9')hi=c1-'0';
+        else if('a'<=c1&&c1<='f')hi=c1-'a'+10;
+        else if('A'<=c1&&c1<='F')hi=c1-'A'+10;
         else return -1;
-        if ('0' <= c2 && c2 <= '9') lo = c2 - '0';
-        else if ('a' <= c2 && c2 <= 'f') lo = c2 - 'a' + 10;
-        else if ('A' <= c2 && c2 <= 'F') lo = c2 - 'A' + 10;
+        if('0'<=c2&&c2<='9')lo=c2-'0';
+        else if('a'<=c2&&c2<='f')lo=c2-'a'+10;
+        else if('A'<=c2&&c2<='F')lo=c2-'A'+10;
         else return -1;
-        uuid->data[j++] = (uint8_t)((hi << 4) | lo);
-        i += 2;
+        uuid->data[j++]=(uint8_t)((hi<<4)|lo);
+        i+=2;
     }
-    if (j != 16) return -1;
-    return 0;
+    return j==16?0:-1;
 }
 void uuid_format(const uuid_t *uuid, char *out){
-    snprintf(out, 37,
-        "%02x%02x%02x%02x-"
-        "%02x%02x-"
-        "%02x%02x-"
-        "%02x%02x-"
-        "%02x%02x%02x%02x%02x%02x",
-        uuid->data[0], uuid->data[1], uuid->data[2], uuid->data[3],
-        uuid->data[4], uuid->data[5],
-        uuid->data[6], uuid->data[7],
-        uuid->data[8], uuid->data[9],
-        uuid->data[10], uuid->data[11], uuid->data[12], uuid->data[13], uuid->data[14], uuid->data[15]
-    );
+    snprintf(out,37,
+        "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+        uuid->data[0],uuid->data[1],uuid->data[2],uuid->data[3],
+        uuid->data[4],uuid->data[5],uuid->data[6],uuid->data[7],
+        uuid->data[8],uuid->data[9],uuid->data[10],uuid->data[11],
+        uuid->data[12],uuid->data[13],uuid->data[14],uuid->data[15]);
 }
 void uuid_print(const uuid_t *uuid){
-    // Print the UUID in the form "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    // Returns number of chars printed
     log_debug(
-        "%02x%02x%02x%02x-"
-        "%02x%02x-"
-        "%02x%02x-"
-        "%02x%02x-"
-        "%02x%02x%02x%02x%02x%02x",
-        uuid->data[0], uuid->data[1], uuid->data[2], uuid->data[3],
-        uuid->data[4], uuid->data[5],
-        uuid->data[6], uuid->data[7],
-        uuid->data[8], uuid->data[9],
-        uuid->data[10], uuid->data[11], uuid->data[12], uuid->data[13], uuid->data[14], uuid->data[15]
-    );
+        "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+        uuid->data[0],uuid->data[1],uuid->data[2],uuid->data[3],
+        uuid->data[4],uuid->data[5],uuid->data[6],uuid->data[7],
+        uuid->data[8],uuid->data[9],uuid->data[10],uuid->data[11],
+        uuid->data[12],uuid->data[13],uuid->data[14],uuid->data[15]);
 }
+
+#endif

--- a/src/utils/uuid.h
+++ b/src/utils/uuid.h
@@ -3,9 +3,14 @@
 #include <string.h>
 #include <stdbool.h>
 
+#ifdef _WIN32
+#include <windows.h>
+typedef UUID uuid_t;
+#else
 typedef struct {
     uint8_t data[16];
 } uuid_t;
+#endif
 
 
 bool uuid_compare(const uuid_t *a, const uuid_t *b);


### PR DESCRIPTION
- WT_EXECUTELONGFUNCTION 避免线程池串行化
- worker 1ms 轮询替代 pthread_cond(#ifdef _WIN32)
- overlay_abort 短 sleep 5ms(#ifdef _WIN32)
- UUID与SDK冲突 , 进行一个type的def